### PR TITLE
Use LinkedHashSet instead of SortedSet for ProjectColumns

### DIFF
--- a/src/main/java/ai/preferred/regression/pe/ProjectColumns.java
+++ b/src/main/java/ai/preferred/regression/pe/ProjectColumns.java
@@ -8,9 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 
 public class ProjectColumns extends ProcessingElement {
 
@@ -19,8 +17,8 @@ public class ProjectColumns extends ProcessingElement {
   @Option(name = "-c", aliases = {"--columns"}, usage = "the column names separated by spaces", handler = StringArrayOptionHandler.class, required = true)
   private String[] columns = new String[0];
 
-  private static SortedSet<Integer> indicesOf(ArrayList<String> header, String[] columns) {
-    final SortedSet<Integer> indices = new TreeSet<>();
+  private static Set<Integer> indicesOf(ArrayList<String> header, String[] columns) {
+    final Set<Integer> indices = new LinkedHashSet<>();
     for (final String name : columns) {
       int index = header.indexOf(name);
       if (index > -1) {
@@ -30,7 +28,7 @@ public class ProjectColumns extends ProcessingElement {
     return indices;
   }
 
-  private static <T> ArrayList<T> projectIndices(ArrayList<T> list, SortedSet<Integer> indices) {
+  private static <T> ArrayList<T> projectIndices(ArrayList<T> list, Set<Integer> indices) {
     final ArrayList<T> projection = new ArrayList<>(indices.size());
     for (int index : indices) {
       projection.add(list.get(index));
@@ -45,7 +43,7 @@ public class ProjectColumns extends ProcessingElement {
     }
 
     final ArrayList<String> header = data.getHeader();
-    final SortedSet<Integer> indices = indicesOf(header, columns);
+    final Set<Integer> indices = indicesOf(header, columns);
     printer.printRecord(projectIndices(header, indices));
 
     for (final ArrayList<String> record : data) {


### PR DESCRIPTION
More in line with user behaviour to expect columns to be sorted according the order the users input the column names rather than sorting based on left-to-right order of the original table